### PR TITLE
Sync with halos-org/shared-workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,8 @@
 # - For lintian checks: .github/actions/build-deb/action.yml (optional)
 #
 # Version bump check:
-# - Requires VERSION file (repo-level) or apps/ directory (app-level)
+# - App-level (apps/*/metadata.yaml): per-PR, requires metadata bump when app files change
+# - Repo-level (VERSION): per-release, requires bump once between stable releases
 # - Automatically skipped for docs, tests, CI, and tooling changes
 
 name: PR Checks
@@ -110,79 +111,6 @@ jobs:
           echo "✅ Lintian checks passed"
 
   version-bump-check:
-    runs-on: ${{ inputs.runs-on }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check if version bumps are needed
-        shell: bash
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          set -euo pipefail
-          FAILED=0
-
-          git fetch origin "$BASE_REF" --depth=1
-
-          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
-
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No files changed"
-            exit 0
-          fi
-
-          # --- Part A: App-level version check ---
-          if [ -d "apps" ]; then
-            # Find app directories with changed non-metadata files
-            CHANGED_APP_DIRS=$(echo "$CHANGED_FILES" \
-              | grep -E '^apps/[^/]+/' \
-              | grep -v '/metadata\.yaml$' \
-              | sed 's|^\(apps/[^/]*\)/.*|\1|' \
-              | sort -u || true)
-
-            for app_dir in $CHANGED_APP_DIRS; do
-              if ! echo "$CHANGED_FILES" | grep -q "^${app_dir}/metadata\.yaml$"; then
-                echo "::error::${app_dir}/ was modified but ${app_dir}/metadata.yaml was not updated."
-                echo "  Bump the version field (e.g., 2.20.2-3 -> 2.20.2-4) in ${app_dir}/metadata.yaml"
-                FAILED=1
-              fi
-            done
-          fi
-
-          # --- Part B: Repo-level VERSION check ---
-          if [ -f "VERSION" ]; then
-            # Filter to non-app, package-affecting files (exclude docs, tests,
-            # CI config, dev tooling, and the VERSION file itself)
-            PACKAGE_FILES=$(echo "$CHANGED_FILES" \
-              | grep -v '^apps/' \
-              | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
-              | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
-              | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
-              | grep -v -E '^(docker/|Dockerfile|docker-compose)' \
-              | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
-              | grep -v -E '^(store/)' \
-              | grep -v -E '\.(lock)$' \
-              | grep -v -E '\.lintian-overrides$' \
-              || true)
-
-            if [ -n "$PACKAGE_FILES" ]; then
-              if ! echo "$CHANGED_FILES" | grep -q '^VERSION$'; then
-                echo "::error::Package-affecting files changed but VERSION was not bumped."
-                echo ""
-                echo "Changed package files:"
-                echo "$PACKAGE_FILES" | sed 's/^/  /'
-                echo ""
-                echo "Run './run bumpversion patch' (or minor/major) to bump the version."
-                FAILED=1
-              fi
-            fi
-          fi
-
-          if [ $FAILED -eq 1 ]; then
-            exit 1
-          fi
-
-          echo "Version bump check passed"
+    uses: ./.github/workflows/version-bump-check.yml
+    with:
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,128 @@
+# Reusable workflow for version bump checks
+# Can be called standalone or from pr-checks.yml
+#
+# Checks:
+# - App-level (apps/*/metadata.yaml): per-PR, requires metadata bump when app files change
+# - Repo-level (VERSION): per-release, requires bump once between stable releases
+# - Automatically skipped for docs, tests, CI, and tooling changes
+
+name: Version Bump Check
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: 'Runner to use'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  version-bump-check:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if version bumps are needed
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          FAILED=0
+
+          git fetch origin "$BASE_REF" --depth=1
+
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No files changed"
+            exit 0
+          fi
+
+          # --- Part A: App-level version check ---
+          if [ -d "apps" ]; then
+            # Find app directories with changed non-metadata files
+            CHANGED_APP_DIRS=$(echo "$CHANGED_FILES" \
+              | grep -E '^apps/[^/]+/' \
+              | grep -v '/metadata\.yaml$' \
+              | sed 's|^\(apps/[^/]*\)/.*|\1|' \
+              | sort -u || true)
+
+            for app_dir in $CHANGED_APP_DIRS; do
+              if ! echo "$CHANGED_FILES" | grep -q "^${app_dir}/metadata\.yaml$"; then
+                echo "::error::${app_dir}/ was modified but ${app_dir}/metadata.yaml was not updated."
+                echo "  Bump the version field (e.g., 2.20.2-3 -> 2.20.2-4) in ${app_dir}/metadata.yaml"
+                FAILED=1
+              fi
+            done
+          fi
+
+          # --- Part B: Repo-level VERSION check (per-release, not per-PR) ---
+          # VERSION must be bumped at least once between stable releases.
+          # Stable releases: v{upstream}+{revision} (no _pre suffix).
+          # Uses gh release list instead of git tags because draft releases
+          # create tags that shouldn't count as stable releases.
+          # Falls back to git tags if the API call fails.
+          if [ -f "VERSION" ]; then
+            CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
+
+            # Find latest stable release (no _pre suffix)
+            # Separate the API call from filtering so API failures aren't silently swallowed
+            if ! RELEASES=$(gh release list --exclude-drafts --exclude-pre-releases \
+              --json tagName --jq '.[].tagName'); then
+              echo "::warning::Failed to fetch releases from GitHub API, falling back to git tags"
+              RELEASES=$(git tag -l 'v*')
+            fi
+            LATEST_STABLE_TAG=$(echo "$RELEASES" \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?\+[0-9]+$' \
+              | sort -V | tail -1 || true)
+
+            if [ -n "$LATEST_STABLE_TAG" ]; then
+              # Extract upstream version from tag (e.g., v0.2.0+3 → 0.2.0)
+              TAGGED_VERSION=$(echo "$LATEST_STABLE_TAG" | sed 's/^v\(.*\)+[0-9]*$/\1/')
+
+              if [ "$CURRENT_VERSION" != "$TAGGED_VERSION" ]; then
+                echo "VERSION ($CURRENT_VERSION) differs from latest stable release ($TAGGED_VERSION) — no bump needed"
+              else
+                # VERSION matches latest stable tag — check if package-affecting files changed
+                PACKAGE_FILES=$(echo "$CHANGED_FILES" \
+                  | grep -v '^apps/' \
+                  | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
+                  | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
+                  | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
+                  | grep -v -E '^(docker/|Dockerfile|docker-compose|config\.)' \
+                  | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
+                  | grep -v -E '^(store/)' \
+                  | grep -v -E '\.(lock)$' \
+                  | grep -v -E '\.lintian-overrides$' \
+                  || true)
+
+                if [ -n "$PACKAGE_FILES" ]; then
+                  echo "::error::Package-affecting files changed but VERSION ($CURRENT_VERSION) still matches the latest stable release ($LATEST_STABLE_TAG)."
+                  echo ""
+                  echo "Changed package files:"
+                  echo "$PACKAGE_FILES" | sed 's/^/  /'
+                  echo ""
+                  echo "VERSION needs to be bumped before the next release."
+                  echo "Run './run bumpversion patch' (or minor/major) — either in this PR or a separate one."
+                  FAILED=1
+                fi
+              fi
+            else
+              echo "No stable release tags found — skipping repo-level version check"
+            fi
+          fi
+
+          if [ $FAILED -eq 1 ]; then
+            exit 1
+          fi
+
+          echo "Version bump check passed"


### PR DESCRIPTION
## Summary

- Extract version-bump-check into standalone reusable workflow (`version-bump-check.yml`)
- Fix stable release detection: use `gh release list --exclude-drafts` instead of `git tag -l` (draft releases create tags that shouldn't count)
- `pr-checks.yml` now delegates to the new workflow

Syncs with halos-org/shared-workflows#22.

closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)